### PR TITLE
Bringing a second example of PCK in initial def'n

### DIFF
--- a/_episodes/02-novice.md
+++ b/_episodes/02-novice.md
@@ -178,7 +178,7 @@ The things teachers know can be divided into:
 
 *   the *pedagogical content knowledge* (PCK) that connects the two,
     which is things like when to teach the notion of a call stack
-    and what examples to use when doing so.
+    and what examples to use when doing so, or knowing what misconceptions about recursion are most common.
 
 ![Pedagogical Content Knowledge]({{ site.root }}/fig/02/pck.svg)
 


### PR DESCRIPTION
When introducing new jargon it's often helpful to have multiple concrete examples. Mentioning misconceptions upfront is a useful example because it's returned to later.